### PR TITLE
Add UHAS, Ho, Ghana

### DIFF
--- a/lib/domains/gh/edu/uhas.txt
+++ b/lib/domains/gh/edu/uhas.txt
@@ -1,0 +1,1 @@
+University of Health and Allied Sciences, Ho, Ghana

--- a/lib/domains/gh/edu/uhas/sahs.txt
+++ b/lib/domains/gh/edu/uhas/sahs.txt
@@ -1,0 +1,1 @@
+UHAS, Ho (School of Allied Health Sciences)

--- a/lib/domains/gh/edu/uhas/sbbs.txt
+++ b/lib/domains/gh/edu/uhas/sbbs.txt
@@ -1,0 +1,1 @@
+UHAS, Ho (School of Basic and Biomedical Sciences)

--- a/lib/domains/gh/edu/uhas/sod.txt
+++ b/lib/domains/gh/edu/uhas/sod.txt
@@ -1,0 +1,1 @@
+UHAS, Ho (School of Dentistry)

--- a/lib/domains/gh/edu/uhas/som.txt
+++ b/lib/domains/gh/edu/uhas/som.txt
@@ -1,0 +1,1 @@
+UHAS, Ho (School of Medicine)

--- a/lib/domains/gh/edu/uhas/sonam.txt
+++ b/lib/domains/gh/edu/uhas/sonam.txt
@@ -1,0 +1,1 @@
+UHAS, Ho (School of Nursing and Midwifery)

--- a/lib/domains/gh/edu/uhas/sop.txt
+++ b/lib/domains/gh/edu/uhas/sop.txt
@@ -1,0 +1,1 @@
+UHAS, Ho (School of Pharmacy)

--- a/lib/domains/gh/edu/uhas/sph.txt
+++ b/lib/domains/gh/edu/uhas/sph.txt
@@ -1,0 +1,1 @@
+UHAS, Ho (School of Public Health)

--- a/lib/domains/gh/edu/uhas/ssem.txt
+++ b/lib/domains/gh/edu/uhas/ssem.txt
@@ -1,0 +1,1 @@
+UHAS, Ho (School of Sports and Exercise Medicine)


### PR DESCRIPTION
This pull request adds the domain for the University of Health and Allied Sciences (UHAS), Ho, Ghana.

- Domain added: sph.uhas.edu.gh
- Purpose: Enable students and staff with emails under this domain to apply for JetBrains educational licenses.

Thank you for reviewing this submission